### PR TITLE
Update package.json.sample

### DIFF
--- a/package.json.sample
+++ b/package.json.sample
@@ -18,7 +18,7 @@
     "grunt-contrib-cssmin": "~4.0.0",
     "grunt-contrib-imagemin": "~4.0.0",
     "grunt-contrib-jasmine": "~4.0.0",
-    "grunt-contrib-less": "~3.0.0",
+    "grunt-contrib-less": "1.4.1",
     "grunt-contrib-watch": "~1.1.0",
     "grunt-eslint": "~24.2.0",
     "grunt-exec": "~3.0.0",


### PR DESCRIPTION
I don't even believe that no one didn't comment this PR https://github.com/magento/magento2/pull/31618 during 2 year. Do you know that styles sourcemaps are broken since updating this package in `package.json`.
each time it has to be fixed for a new project.
grunt-contrib-less `1.4.1`:
<img width="564" alt="image" src="https://github.com/magento/magento2/assets/28815318/86b2c561-74ca-4aa0-a9e3-411cdbc05a97">

grunt-contrib-less `~2.1.0`:
<img width="534" alt="image" src="https://github.com/magento/magento2/assets/28815318/f00fb719-aa15-4bd3-b3dc-efe796d969fe">

you ask for self-checking, tests running, screenshots, but don't check the first development steps when you update something. that's weird.

steps to reproduce:
1. setup a new theme
2. prepare Grunt files
3. run npm install
4. run `grunt clean:theme && exec:theme && less:theme`
5. see that sourcemaps not generated even if you disable static sign, cache, browser cache, etc.
6. restore the package version to `1.4.1` from `~2.1.0`
7. run `npm i`
8. repeat the 4th step
9. see sourcemaps in the browser's devtools.

video example that includes the fix (use subtitles) with timecode:
https://youtu.be/NEKvPRTW9mM?si=2f_ZXV-WNR8IyN9N&t=699

that's even funny that in M2.4.7 beta this package is update to `~3.0.0` 
https://github.com/magento/magento2/commit/203f415cd5f314401a335991bd97919e3baa9dc3

but it couldn't be compiled with error:
```
Running "less:demo" (less) task
>> pub/static/frontend/Vaimo/demo/en_US/css/source/_reset.less: [L7:C4] Error evaluating function `unit`: the first argument to unit must be a number. Have you forgotten parenthesis?
Warning: Error compiling pub/static/frontend/Vaimo/demo/en_US/css/styles-m.less Use --force to continue.

Aborted due to warnings.
```
<img width="1492" alt="image" src="https://github.com/magento/magento2/assets/28815318/ac242bbe-5dee-45f3-9502-bae3ac3eb345">
